### PR TITLE
check if resume is a function before calling it

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,22 @@
 var Writable = require('stream').Writable;
 var inherits = require('util').inherits;
 
-module.exports = resumer
+module.exports = resumer;
 
 function resumer(stream) {
   if (!stream.readable) {
     return stream;
   }
 
-  stream._read ? stream.pipe(new Sink) : stream.resume();
+  if (stream._read) {
+    stream.pipe(new Sink);
+    return stream;
+  }
+
+  if (typeof stream.resume === 'function') {
+    stream.resume();
+    return stream;
+  }
 
   return stream;
 }

--- a/test.js
+++ b/test.js
@@ -185,4 +185,25 @@ test('should not modify .pipe', function(assert) {
 
   assert.equal(stream.pipe, pipe);
   assert.end();
-})
+});
+
+test('does not error on no resume but readable set to true', function(assert) {
+  var rs = new Stream();
+  rs.readable = true;
+
+  var ended = false;
+  var i;
+
+  rs.on("end", function() {
+    assert.ok(ended, 'ended is true');
+    assert.end();
+  });
+
+  exhaust(rs);
+
+  for (i = 0; i < 100; i++) {
+    rs.emit("data", i);
+  }
+  ended = true;
+  rs.emit("end");
+});


### PR DESCRIPTION
I am not going to support returning `event-stream` in gulp4, but I also don't want to crash if it is returned (it just won't sink).  Made some changes to check for `resume` before calling it 

ref https://github.com/ivogabe/gulp-typescript/issues/48