### PR TITLE
Rename Sink#_write parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,6 @@ function Sink() {
 
 inherits(Sink, Writable);
 
-Sink.prototype._write = function(_, _, cb) {
+Sink.prototype._write = function(chunk, encoding, cb) {
   setImmediate(cb);
 };


### PR DESCRIPTION
Because some compiler not allowed duplicate parameter name (for example ClojureScript)